### PR TITLE
Create SSE bridge between MCP client and Chatmi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+.vercel

--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
-# mcp-webim
+# MCP ↔ Chatmi bridge
+
+This repository contains a lightweight HTTP service that exposes a Server-Sent Events (SSE) endpoint for an MCP client and forwards inbound MCP messages to the Chatmi webhook. The service can be deployed to Vercel and also includes a tiny local development server.
+
+## Architecture overview
+
+The service exposes two HTTP endpoints:
+
+- `GET /api/stream?client_id=...` — establishes the SSE channel that the MCP client listens to. Responses from Chatmi are emitted as SSE events.
+- `POST /api/message` — accepts MCP JSON RPC payloads from the client and forwards them to Chatmi. The body must contain a `client_id` string and a `message` object (the MCP payload).
+
+When `/api/message` is called, the service serialises the MCP payload into a string that Chatmi understands, sends it to Chatmi via the webhook, parses the synchronous response, and pushes every returned event to the SSE stream of the matching `client_id`.
+
+## Chatmi message formats
+
+Chatmi communicates purely through JSON strings. The bridge always sends and receives strings that conform to the following schema.
+
+### Input string sent to Chatmi
+
+```
+{
+  "version": "0.1.0",
+  "client": {
+    "id": "<CLIENT_ID>"
+  },
+  "message": <MCP_JSON_RPC_OBJECT>
+}
+```
+
+- `<CLIENT_ID>` — the value supplied in the `client_id` field when calling `/api/message`.
+- `<MCP_JSON_RPC_OBJECT>` — the exact JSON payload received from the MCP client (for example, an `initialize` request or a `call_tool` notification).
+
+The entire structure above is serialised with `JSON.stringify` and provided to Chatmi in the `text` field of the webhook call.
+
+### Output string returned by Chatmi
+
+Chatmi must reply with an operator message whose `text` field contains a JSON string with this structure:
+
+```
+{
+  "version": "0.1.0",
+  "client": {
+    "id": "<CLIENT_ID>"
+  },
+  "events": [
+    {
+      "name": "<SSE_EVENT_NAME>",
+      "payload": <ANY_JSON_PAYLOAD>
+    },
+    ...
+  ]
+}
+```
+
+- `<CLIENT_ID>` must match the identifier from the request.
+- Every element inside `events` represents one message that will be emitted over SSE. The `name` field is optional; if omitted, the bridge falls back to `message`. The `payload` can contain any JSON-serialisable object that the MCP client expects.
+
+Each event is emitted as:
+
+```
+event: <SSE_EVENT_NAME>
+data: <payload serialized with JSON.stringify>
+```
+
+## Local development
+
+1. Install the Vercel CLI if you want to use `vercel dev`, or simply rely on the bundled Node server.
+2. Create a `.env` file (optional) and set `CHATMI_WEBHOOK_URL` if you need to override the default URL.
+3. Run the local server:
+
+   ```bash
+   npm install
+   npm run start
+   ```
+
+   or with Vercel:
+
+   ```bash
+   npm run dev
+   ```
+
+4. Connect your MCP client to `http://localhost:3000/api/stream?client_id=<YOUR_ID>` and POST messages to `http://localhost:3000/api/message`.
+
+## Deployment to Vercel
+
+1. Ensure the `CHATMI_WEBHOOK_URL` environment variable is configured in the Vercel project if the default value should be overridden.
+2. Deploy the project with `vercel --prod`.
+3. Configure your MCP client to use the deployed SSE endpoint and message endpoint in the same way as in local development.

--- a/api/local-server.js
+++ b/api/local-server.js
@@ -1,0 +1,37 @@
+const http = require('http');
+const url = require('url');
+
+const streamHandler = require('./stream');
+const messageHandler = require('./message');
+
+const server = http.createServer((req, res) => {
+  const parsedUrl = url.parse(req.url, true);
+  req.query = parsedUrl.query;
+
+  if (req.method === 'GET' && parsedUrl.pathname === '/api/stream') {
+    streamHandler(req, res);
+    return;
+  }
+
+  if (req.method === 'POST' && parsedUrl.pathname === '/api/message') {
+    messageHandler(req, res);
+    return;
+  }
+
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization');
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end('Not Found');
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+  console.log(`Local dev server listening on http://localhost:${port}`);
+});

--- a/api/message.js
+++ b/api/message.js
@@ -1,0 +1,120 @@
+const url = require('url');
+const { sendEvent, getClient } = require('../lib/clientStore');
+const { setCorsHeaders, readJsonBody } = require('../lib/http');
+const { buildChatmiInput, parseChatmiOutput } = require('../lib/chatmiFormats');
+
+const CHATMI_WEBHOOK_URL = process.env.CHATMI_WEBHOOK_URL || 'https://admin.chatme.ai/connector/webim/webim_message/a7e28b914256ab13395ec974e7bb9548/bot_api_webhook';
+
+module.exports = async function handler(req, res) {
+  setCorsHeaders(res);
+
+  if (!req.query) {
+    const parsedUrl = url.parse(req.url, true);
+    req.query = parsedUrl.query || {};
+  }
+
+  if (req.method === 'OPTIONS') {
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    res.setHeader('Allow', 'POST,OPTIONS');
+    res.end(JSON.stringify({ error: 'Method not allowed' }));
+    return;
+  }
+
+  let body;
+  try {
+    body = await readJsonBody(req);
+  } catch (error) {
+    res.statusCode = 400;
+    res.end(JSON.stringify({ error: error.message }));
+    return;
+  }
+
+  const { client_id: clientId, message } = body;
+  if (!clientId || typeof clientId !== 'string') {
+    res.statusCode = 400;
+    res.end(JSON.stringify({ error: 'client_id must be provided as a string' }));
+    return;
+  }
+  if (!message || typeof message !== 'object') {
+    res.statusCode = 400;
+    res.end(JSON.stringify({ error: 'message must be provided as an object' }));
+    return;
+  }
+
+  if (!getClient(clientId)) {
+    res.statusCode = 404;
+    res.end(JSON.stringify({ error: `No active SSE connection for client ${clientId}` }));
+    return;
+  }
+
+  const chatmiInput = buildChatmiInput({ clientId, message });
+
+  let chatmiResponse;
+  try {
+    const response = await fetch(CHATMI_WEBHOOK_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        event: 'new_message',
+        chat: { id: clientId },
+        text: chatmiInput,
+      }),
+    });
+
+    if (!response.ok) {
+      const responseText = await response.text();
+      throw new Error(`Chatmi request failed (${response.status}): ${responseText}`);
+    }
+
+    chatmiResponse = await response.json();
+  } catch (error) {
+    res.statusCode = 502;
+    res.end(JSON.stringify({ error: error.message }));
+    return;
+  }
+
+  if (!chatmiResponse.has_answer || !Array.isArray(chatmiResponse.messages)) {
+    res.statusCode = 502;
+    res.end(JSON.stringify({ error: 'Unexpected Chatmi response format' }));
+    return;
+  }
+
+  const operatorMessage = chatmiResponse.messages.find((msg) => msg && msg.kind === 'operator');
+  if (!operatorMessage || typeof operatorMessage.text !== 'string') {
+    res.statusCode = 502;
+    res.end(JSON.stringify({ error: 'Chatmi response does not contain an operator message' }));
+    return;
+  }
+
+  let parsed;
+  try {
+    parsed = parseChatmiOutput(operatorMessage.text);
+  } catch (error) {
+    res.statusCode = 502;
+    res.end(JSON.stringify({ error: error.message }));
+    return;
+  }
+
+  const { events } = parsed;
+  try {
+    events.forEach((event) => {
+      const { name = 'message', payload = event } = event;
+      sendEvent(clientId, name, payload);
+    });
+  } catch (error) {
+    res.statusCode = 500;
+    res.end(JSON.stringify({ error: error.message }));
+    return;
+  }
+
+  res.statusCode = 200;
+  res.end(JSON.stringify({ delivered: events.length }));
+};

--- a/api/stream.js
+++ b/api/stream.js
@@ -1,0 +1,49 @@
+const url = require('url');
+const { registerClient, removeClient, sendEvent } = require('../lib/clientStore');
+const { setCorsHeaders } = require('../lib/http');
+
+module.exports = async function handler(req, res) {
+  setCorsHeaders(res);
+
+  if (!req.query) {
+    const parsedUrl = url.parse(req.url, true);
+    req.query = parsedUrl.query || {};
+  }
+
+  if (req.method === 'OPTIONS') {
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    res.statusCode = 405;
+    res.setHeader('Allow', 'GET,OPTIONS');
+    res.end(JSON.stringify({ error: 'Method not allowed' }));
+    return;
+  }
+
+  const { client_id: clientId } = req.query;
+  if (!clientId) {
+    res.statusCode = 400;
+    res.end(JSON.stringify({ error: 'client_id query parameter is required' }));
+    return;
+  }
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+
+  registerClient(clientId, res);
+
+  sendEvent(clientId, 'ready', {
+    message: 'SSE connection established',
+    clientId,
+  });
+
+  req.on('close', () => {
+    removeClient(clientId);
+  });
+};

--- a/lib/chatmiFormats.js
+++ b/lib/chatmiFormats.js
@@ -1,0 +1,45 @@
+const CHATMI_PROTOCOL_VERSION = '0.1.0';
+
+function buildChatmiInput({ clientId, message }) {
+  const payload = {
+    version: CHATMI_PROTOCOL_VERSION,
+    client: {
+      id: clientId,
+    },
+    message,
+  };
+
+  return JSON.stringify(payload);
+}
+
+function parseChatmiOutput(rawText) {
+  if (!rawText) {
+    throw new Error('Chatmi response is empty');
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch (error) {
+    throw new Error('Chatmi response is not valid JSON');
+  }
+
+  if (parsed.version !== CHATMI_PROTOCOL_VERSION) {
+    throw new Error(`Unsupported Chatmi protocol version: ${parsed.version}`);
+  }
+
+  if (!parsed.client || typeof parsed.client.id !== 'string') {
+    throw new Error('Chatmi response is missing client.id');
+  }
+
+  if (!Array.isArray(parsed.events)) {
+    throw new Error('Chatmi response is missing events array');
+  }
+
+  return parsed;
+}
+
+module.exports = {
+  buildChatmiInput,
+  parseChatmiOutput,
+  CHATMI_PROTOCOL_VERSION,
+};

--- a/lib/clientStore.js
+++ b/lib/clientStore.js
@@ -1,0 +1,37 @@
+const clients = new Map();
+
+function registerClient(clientId, res) {
+  clients.set(clientId, res);
+}
+
+function removeClient(clientId) {
+  const client = clients.get(clientId);
+  if (client) {
+    try {
+      client.end();
+    } catch (error) {
+      console.error('Error closing client response', error);
+    }
+  }
+  clients.delete(clientId);
+}
+
+function getClient(clientId) {
+  return clients.get(clientId);
+}
+
+function sendEvent(clientId, eventName, payload) {
+  const res = clients.get(clientId);
+  if (!res) {
+    throw new Error(`No active SSE connection for client ${clientId}`);
+  }
+  res.write(`event: ${eventName}\n`);
+  res.write(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+module.exports = {
+  registerClient,
+  removeClient,
+  getClient,
+  sendEvent,
+};

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,0 +1,27 @@
+function setCorsHeaders(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization');
+}
+
+async function readJsonBody(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  const raw = Buffer.concat(chunks).toString('utf8');
+  if (!raw) {
+    return {};
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    error.message = `Unable to parse JSON body: ${error.message}`;
+    throw error;
+  }
+}
+
+module.exports = {
+  setCorsHeaders,
+  readJsonBody,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "mcp-webim",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp-webim",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "mcp-webim",
+  "version": "0.1.0",
+  "private": true,
+  "description": "SSE bridge between an MCP client and Chatme webhook",
+  "scripts": {
+    "dev": "vercel dev",
+    "start": "node api/local-server.js"
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/**/*.js": {
+      "runtime": "nodejs18.x"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement SSE stream endpoint and POST relay that connects an MCP client with the Chatmi webhook
- add utility modules for SSE client bookkeeping, HTTP helpers, and Chatmi payload serialisation
- document the bridge architecture, Chatmi string formats, and local/Vercel deployment flow

## Testing
- node -e "require('./api/stream'); require('./api/message'); console.log('Handlers loaded');"

------
https://chatgpt.com/codex/tasks/task_e_68dbdc91d85c8321ae7fad3de9481a12