### PR TITLE
Add version to Vercel configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "functions": {
     "api/**/*.js": {
       "runtime": "nodejs18.x"


### PR DESCRIPTION
## Summary
- add the missing `version` property to the Vercel configuration so `nodejs18.x` runtime is recognized

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe6f863bc8321a7d6f6d30363be90