### PR TITLE
Update Vercel function runtime configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "functions": {
     "api/**/*.js": {
-      "runtime": "nodejs18.x"
+      "runtime": "@vercel/node@5.3.24"
     }
   }
 }


### PR DESCRIPTION
## Summary
- update the serverless function runtime definition to use the official `@vercel/node@5.3.24` identifier so the Vercel build passes runtime validation

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbe7c0d4608321973ea152a7810486